### PR TITLE
Modifications to support compilation on Windows/MSVC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build/*
 out/*
 in/*
 in_jak1/*
+.vs/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,10 +3,41 @@ project(jak2_disassembler)
 
 set(CMAKE_CXX_STANDARD 14)
 
-set(CMAKE_CXX_FLAGS "-O3 -ggdb -Wall \
--Wextra -Wcast-align -Wcast-qual -Wdisabled-optimization -Wformat=2 \
--Winit-self -Wmissing-include-dirs -Woverloaded-virtual \
--Wredundant-decls -Wshadow -Wsign-promo ")
+set(CMAKE_CXX_FLAGS "-O3 -ggdb")
 
-add_executable(jak2_disassembler util/LispPrint.cpp main.cpp ObjectFileDB.cpp Disasm/Instruction.cpp Disasm/InstructionDecode.cpp Disasm/OpcodeInfo.cpp Disasm/Register.cpp LinkedObjectFileCreation.cpp LinkedObjectFile.cpp Function/Function.cpp util/FileIO.cpp minilzo/minilzo.c game_version.cpp game_version.h util/LispPrint.cpp util/LispPrint.h)
+# Set default compile flags for GCC
+if(CMAKE_COMPILER_IS_GNUCXX)
+    message(STATUS "GCC detected, adding compile flags")
+    set(CMAKE_CXX_FLAGS 
+        "${CMAKE_CXX_FLAGS} 
+        -Wall-Winit-self 
+        -Wextra
+        -Wcast-align
+        -Wcast-qual
+        -Wdisabled-optimization
+        -Wformat=2
+        -Wmissing-include-dirs
+        -Woverloaded-virtual
+        -Wredundant-decls
+        -Wshadow
+        -Wsign-promo")
+endif(CMAKE_COMPILER_IS_GNUCXX)
+
+add_executable(jak2_disassembler
+    util/LispPrint.cpp main.cpp
+    ObjectFileDB.cpp
+    Disasm/Instruction.cpp
+    Disasm/InstructionDecode.cpp
+    Disasm/OpcodeInfo.cpp
+    Disasm/Register.cpp
+    LinkedObjectFileCreation.cpp
+    LinkedObjectFile.cpp
+    Function/Function.cpp
+    util/FileIO.cpp
+    minilzo/minilzo.c
+    game_version.cpp
+    game_version.h
+    util/LispPrint.cpp
+    util/LispPrint.h
+    util/Timer.cpp)
 target_include_directories(jak2_disassembler PRIVATE .)

--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -1,0 +1,16 @@
+﻿{
+	// See https://go.microsoft.com//fwlink//?linkid=834763 for more information about this file.
+	"configurations": [
+		{
+			"name": "x64-Debug",
+			"generator": "Ninja",
+			"configurationType": "Debug",
+			"inheritEnvironments": [ "msvc_x64_x64" ],
+			"buildRoot": "${projectDir}\\out\\build\\${name}",
+			"installRoot": "${projectDir}\\out\\install\\${name}",
+			"cmakeCommandArgs": "",
+			"buildCommandArgs": "",
+			"ctestCommandArgs": ""
+		}
+	]
+}

--- a/main.cpp
+++ b/main.cpp
@@ -9,23 +9,22 @@ int main(int argc, char** argv) {
   init_crc();
   init_opcode_info();
 
-
-  if(argc < 3) {
+  if (argc < 3) {
     printf("usage: jak2_disassembler <output path> <dgos>\n");
     return 1;
   }
 
   std::string output_path = argv[1];
   std::vector<std::string> dgos;
-  for(int i = 2; i < argc; i++) {
+  for (int i = 2; i < argc; i++) {
     dgos.emplace_back(argv[i]);
   }
 
-//  printf("output folder is %s\n", output_path.c_str());
-//  printf("input dgos are:\n");
-//  for(auto& dgo : dgos) {
-//    printf("  %s\n", dgo.c_str());
-//  }
+  //  printf("output folder is %s\n", output_path.c_str());
+  //  printf("input dgos are:\n");
+  //  for(auto& dgo : dgos) {
+  //    printf("  %s\n", dgo.c_str());
+  //  }
 
   ObjectFileDB db(dgos);
   write_text_file(combine_path(output_path, "dgo.txt"), db.generate_dgo_listing());
@@ -35,7 +34,7 @@ int main(int argc, char** argv) {
   db.process_labels();
   db.find_scripts(output_path);
 
-//  db.write_object_file_words(output_path, false);
+  //  db.write_object_file_words(output_path, false);
   db.write_disassembly(output_path);
 
   return 0;

--- a/util/Timer.cpp
+++ b/util/Timer.cpp
@@ -1,0 +1,54 @@
+#include "Timer.h"
+
+#ifdef _WIN32
+#include <Windows.h>
+#define MS_PER_SEC 1000ULL  // MS = milliseconds
+#define US_PER_MS 1000ULL   // US = microseconds
+#define HNS_PER_US 10ULL    // HNS = hundred-nanoseconds (e.g., 1 hns = 100 ns)
+#define NS_PER_US 1000ULL
+
+#define HNS_PER_SEC (MS_PER_SEC * US_PER_MS * HNS_PER_US)
+#define NS_PER_HNS (100ULL)  // NS = nanoseconds
+#define NS_PER_SEC (MS_PER_SEC * US_PER_MS * NS_PER_US)
+
+int Timer::clock_gettime_monotonic(struct timespec* tv) {
+  static LARGE_INTEGER ticksPerSec;
+  LARGE_INTEGER ticks;
+  double seconds;
+
+  if (!ticksPerSec.QuadPart) {
+    QueryPerformanceFrequency(&ticksPerSec);
+    if (!ticksPerSec.QuadPart) {
+      errno = ENOTSUP;
+      return -1;
+    }
+  }
+
+  QueryPerformanceCounter(&ticks);
+
+  seconds = (double)ticks.QuadPart / (double)ticksPerSec.QuadPart;
+  tv->tv_sec = (time_t)seconds;
+  tv->tv_nsec = (long)((ULONGLONG)(seconds * NS_PER_SEC) % NS_PER_SEC);
+
+  return 0;
+}
+#endif
+
+void Timer::start() {
+#ifdef __linux__
+  clock_gettime(CLOCK_MONOTONIC, &_startTime);
+#elif _WIN32
+  clock_gettime_monotonic(&_startTime);
+#endif
+}
+
+int64_t Timer::getNs() {
+  struct timespec now = {};
+#ifdef __linux__
+  clock_gettime(CLOCK_MONOTONIC, &now);
+#elif _WIN32
+  clock_gettime_monotonic(&now);
+#endif;
+  return (int64_t)(now.tv_nsec - _startTime.tv_nsec) +
+         1000000000 * (now.tv_sec - _startTime.tv_sec);
+}

--- a/util/Timer.h
+++ b/util/Timer.h
@@ -9,44 +9,39 @@
  * Timer for measuring time elapsed with clock_monotonic
  */
 class Timer {
-public:
-
+ public:
   /*!
    * Construct and start timer
    */
   explicit Timer() { start(); }
 
+#ifdef _WIN32
+  int clock_gettime_monotonic(struct timespec* tv);
+#endif
+
   /*!
    * Start the timer
    */
-  void start() { clock_gettime(CLOCK_MONOTONIC, &_startTime); }
+  void start();
 
   /*!
    * Get milliseconds elapsed
    */
-  double getMs() const { return (double)getNs() / 1.e6; }
+  double getMs() { return (double)getNs() / 1.e6; }
 
-  double getUs() const {
-    return (double)getNs() / 1.e3;
-  }
+  double getUs() { return (double)getNs() / 1.e3; }
 
   /*!
    * Get nanoseconds elapsed
    */
-  int64_t getNs() const {
-    struct timespec now = {};
-    clock_gettime(CLOCK_MONOTONIC, &now);
-    return (int64_t)(now.tv_nsec - _startTime.tv_nsec) +
-           1000000000 * (now.tv_sec - _startTime.tv_sec);
-  }
+  int64_t getNs();
 
   /*!
    * Get seconds elapsed
    */
-  double getSeconds() const { return (double)getNs() / 1.e9; }
+  double getSeconds() { return (double)getNs() / 1.e9; }
 
   struct timespec _startTime = {};
 };
 
-
-#endif //JAK_V2_TIMER_H
+#endif  // JAK_V2_TIMER_H


### PR DESCRIPTION
Main issue was around `clock_gettime(CLOCK_MONOTONIC, &_startTime);` but also a lot of compiler flags supported by GCC aren't supported by MSVC it seems.

I would suggest test compiling on gcc/linux prior to merging.